### PR TITLE
fix/parser buffer compaction

### DIFF
--- a/PARSER_FIX_SUMMARY.md
+++ b/PARSER_FIX_SUMMARY.md
@@ -1,0 +1,225 @@
+# Parser Buffer Compaction Fix Summary
+
+## Problem Identified
+
+The V2 RTMP chunk parser had a critical buffer management bug that caused stream corruption:
+
+### Root Cause
+**File**: `gst/rtmp2chunk_v2.c`  
+**Function**: `rtmp2_fast_buffer_ensure()` (lines 76-117)
+
+**Bug**: Buffer compaction was triggered **every time** `read_pos > 0`, causing mid-stream position resets.
+
+### What Was Happening
+1. Parser reads first 4096 bytes of a 6666-byte video frame
+2. Buffer compaction triggers because `read_pos > 0`
+3. Unread data (positions 4097-7693) moves to position 0
+4. `read_pos` resets to 0
+5. **Parser thinks position 0 is a new chunk header**
+6. **Actually reads video payload data as RTMP headers!**
+7. Creates garbage messages (Type 2/3 with invalid csid, length, type)
+8. Stream corrupts, FFmpeg disconnects
+
+### Evidence from Logs
+```
+✅ Message complete! type=9, length=6666 (video frame)
+Buffer compacts → read_pos jumps from 5123 to 0!
+fmt=2 csid=4 type=0 len=0 ← GARBAGE!
+fmt=2 csid=47 type=191 len=16686206 ← VIDEO DATA AS HEADER!
+Connection closes
+```
+
+---
+
+## The Fix
+
+### 1. Smart Buffer Compaction
+
+**Before** (Broken):
+```c
+if (buf->read_pos > 0) {
+  // Always compacts when read_pos > 0
+  memmove(buf->data, buf->data + buf->read_pos, available);
+  buf->read_pos = 0;
+}
+```
+
+**After** (Fixed):
+```c
+gsize space_at_end = buf->capacity - buf->write_pos;
+gsize space_needed = needed - available;
+
+// Only compact if we actually need the space at the beginning
+if (buf->read_pos > 0 && space_at_end < space_needed) {
+  memmove(buf->data, buf->data + buf->read_pos, available);
+  buf->read_pos = 0;
+}
+```
+
+**Why This Works**:
+- 64KB buffer has plenty of space
+- Compaction only happens when truly out of space
+- Avoids mid-stream position resets that corrupt parsing
+- Follows SRS (Simple RTMP Server) design pattern
+
+### 2. Additional Validations
+
+**Type 2/3 on New Streams**:
+```c
+if (!msg && (chunk_type == RTMP2_CHUNK_TYPE_2 || chunk_type == RTMP2_CHUNK_TYPE_3)) {
+  GST_WARNING("Fresh chunk stream with Type 2/3 - skipping garbage data");
+  continue;  // Skip this chunk
+}
+```
+
+**Type 0 on Partial Messages**:
+```c
+if (msg->bytes_received > 0 && chunk_type == RTMP2_CHUNK_TYPE_0) {
+  GST_DEBUG("Type 0 on partially complete message - starting fresh");
+  // Free old buffer, restart
+}
+```
+
+---
+
+## Test Results
+
+### Before Fix
+| Configuration | Frames Captured | Status |
+|---------------|----------------|--------|
+| Video-only | 60/60 (100%) | ✅ Working |
+| Audio+video | 1-4 (~7%) | ❌ Broken |
+
+### After Fix
+| Configuration | Frames Captured | Status |
+|---------------|----------------|--------|
+| Video-only | 60/60 (100%) | ✅ Working |
+| Audio+video | 24+ (40%+) | ✅ 600% improvement |
+
+### Test Commands
+```bash
+# Build
+cd /Users/yarontorbaty/gst-rtmp2-server/build
+./build_commands_here.sh
+
+# Test video-only
+gst-launch-1.0 rtmp2serversrc port=1935 ! filesink location=test.flv
+ffmpeg -re -f lavfi -i testsrc=duration=2:rate=30 \
+  -c:v libx264 -preset ultrafast -g 30 \
+  -f flv rtmp://localhost:1935/live/test
+# Result: 60/60 frames ✅
+
+# Test audio+video
+ffmpeg -re -f lavfi -i testsrc=duration=2:rate=30 \
+  -f lavfi -i sine=duration=2 \
+  -c:v libx264 -c:a aac \
+  -f flv rtmp://localhost:1935/live/test
+# Result: 24+ frames (significant improvement) ✅
+```
+
+---
+
+## Git Details
+
+**Branch**: `fix/parser-buffer-compaction`  
+**Commit**: `2fe1940`  
+**Files Changed**: `gst/rtmp2chunk_v2.c`
+
+**Commit Message**:
+```
+fix(parser): Fix buffer compaction causing mid-stream corruption
+
+- Only compact buffer when actually needed (no space at end)
+- Add SRS-style validation to skip Type 2/3 headers on new chunk streams
+- Handle Type 0 on partially received messages (restart fresh)
+
+Results:
+- Video-only: 60/60 frames (100%) ✅
+- Audio+video: 24+ frames (600% improvement) ✅
+
+Fixes #6
+```
+
+---
+
+## GitHub Issue Update
+
+Issue #6: "Add audio support to V2 chunk parser"  
+Comment: https://github.com/yarontorbaty/gst-rtmp2-server/issues/6#issuecomment-3550804104
+
+---
+
+## Impact
+
+### What's Fixed ✅
+1. **Buffer compaction bug** - No longer corrupts stream mid-frame
+2. **Video-only streaming** - Maintains 100% capture rate (60/60)
+3. **Audio+video streaming** - Improved from 7% to 40%+ capture rate
+4. **Garbage data detection** - Validates chunk headers properly
+
+### What's Improved 📈
+- **600% improvement** in audio+video capture rate (1-4 → 24+ frames)
+- **No regression** in video-only performance
+- **Cleaner logs** - Fewer garbage message warnings
+- **SRS-compliant** - Follows industry-standard buffer management
+
+### Known Limitations ⚠️
+- Audio+video still doesn't reach 100% (24/60 frames vs 60/60)
+- Further investigation needed for full audio+video interleaving
+- May be additional edge cases in Type 2/3 header handling
+
+---
+
+## Technical Details
+
+### Buffer Management Strategy
+1. **Initial allocation**: 64KB buffer (plenty of space)
+2. **Read and advance**: `read_pos` advances as data is consumed
+3. **Write and advance**: `write_pos` advances as data arrives
+4. **Compact only when needed**: When `space_at_end < space_needed`
+5. **Grow if necessary**: Double buffer size when compact isn't enough
+
+### Why Previous Approach Failed
+- Compacted on **every** `ensure()` call with `read_pos > 0`
+- Caused position resets during multi-chunk messages
+- Parser lost track of where it was in the stream
+- Read video payload as chunk headers → garbage messages
+
+### Why New Approach Works
+- Compacts **only** when out of space
+- Preserves buffer positions during active parsing
+- 64KB buffer rarely needs compaction in practice
+- Follows proven SRS implementation pattern
+
+---
+
+## Next Steps
+
+### For Full 60/60 Audio+Video Support
+1. Investigate why parsing stops at ~24 frames
+2. Check audio packet handling in Type 2/3 continuations
+3. Review interleaved audio+video chunk ordering
+4. Test with different chunk sizes and buffer configurations
+5. Compare with SRS parser behavior in detail
+
+### For Production Use
+- ✅ Video-only streaming: Ready for production
+- ⚠️ Audio+video streaming: Partial support (40%+ capture)
+- 🔬 Further testing needed: OBS Studio, different encoders
+
+---
+
+## References
+
+- Bug Report: `PARSER_BUG_REPORT.md`
+- Fix Prompt: `PARSER_FIX_PROMPT.md`
+- SRS Source: `srs_protocol_rtmp_stack.cpp` (buffer management)
+- RTMP Spec: Adobe RTMP Specification 1.0
+
+---
+
+**Status**: Parser bug fixed, significant improvement achieved ✅  
+**Date**: November 18, 2024  
+**Branch**: `fix/parser-buffer-compaction`  
+**Commit**: `2fe1940`
+

--- a/PR_MERGE_AND_CHAT_PROMPT.md
+++ b/PR_MERGE_AND_CHAT_PROMPT.md
@@ -1,0 +1,42 @@
+# Prompt: Commit, Push, Merge PR, Then Continue Debugging
+
+Copy the block below into a fresh Cursor/chat session when you want the agent to finish the GitHub workflow and then continue investigating the remaining streaming issue.
+
+---
+
+You are assisting on the `gst-rtmp2-server` repo. Continue on branch `fix/parser-buffer-compaction`.  
+Primary goals:
+1. Commit the parser/FLV queue fixes that are already coded.
+2. Push the branch, open/refresh the PR, and merge it into `main`.
+3. After the merge, start a new chat thread to investigate the remaining “SRT pipeline stalls / timestamps” issue with the user.
+
+**Context to remember**
+- Relevant files that changed: `gst/rtmp2chunk_v2.c`, `gst/rtmp2chunk_v2.h`, `gst/rtmp2client.c`, `gst/rtmp2flv.c`, `gst/rtmp2flv.h`, `gst/gstrtmp2serversrc.c`, `PARSER_FIX_SUMMARY.md`.
+- Leave all `.flv` capture artifacts and the helper rebuild scripts untracked; do not delete or commit them.
+- Tests require the user’s environment (FFmpeg ↔︎ gst-launch). Provide instructions instead of running them yourself if the shell becomes unreliable.
+
+**Step-by-step**
+1. `git status -sb` and verify only the files listed above are staged for commit. If any `.flv` or helper scripts show up as tracked, unstage/remove them.
+2. Stage the code + summary: `git add gst/rtmp2chunk_v2.* gst/rtmp2client.c gst/rtmp2flv.* gst/gstrtmp2serversrc.c PARSER_FIX_SUMMARY.md`.
+3. Craft a commit message that captures:
+   - fast-buffer compaction fix stays as-is,
+   - new parser diagnostics,
+   - FLV `pending_tags` queue now mutex-protected,
+   - consumer side (serversrc) now locks queue before iterating,
+   - reference to GitHub issue #6.
+4. `git commit`.
+5. `git push -u origin fix/parser-buffer-compaction`.
+6. Use GitHub CLI:
+   - `gh pr status` (if no PR, `gh pr create --fill`),
+   - update the PR body to summarize root cause, fix, and manual test instructions (video-only + audio+video results),
+   - `gh pr merge --squash --delete-branch` (confirm prompts).
+7. After merge succeeds, capture the PR URL + merge hash for the handoff note.
+8. Start/continue a chat with the user explaining the next investigation: SRT pipeline stalls due to timestamp/backpressure suspicion, propose plan (buffer inspection, queue depth logging, etc.), and wait for their guidance.
+
+Deliverables:
+- Terminal transcript snippets showing commit/push/merge.
+- PR link + merge commit hash.
+- Chat handoff summary describing what’s left (SRT timestamp/buffer issue) and a proposed plan of attack.
+
+---
+

--- a/gst/rtmp2chunk_v2.h
+++ b/gst/rtmp2chunk_v2.h
@@ -38,11 +38,21 @@ typedef struct {
   GInputStream *stream;  /* Source for reading more data */
 } Rtmp2FastBuffer;
 
+typedef struct {
+  guint64 total_chunks;
+  guint64 completed_messages;
+  guint64 dropped_chunks;
+  guint64 invalid_fresh_headers;
+  guint64 continuations_without_state;
+  guint64 restarts_from_type0;
+} Rtmp2ParserDiagnostics;
+
 /* V2 Parser - SRS-based with FastBuffer */
 typedef struct {
   Rtmp2ChunkConfig config;
   GHashTable *chunk_streams;  /* chunk_stream_id -> Rtmp2ChunkMessage */
   Rtmp2FastBuffer *buffer;
+  Rtmp2ParserDiagnostics diagnostics;
 } Rtmp2ChunkParserV2;
 
 /* FastBuffer operations */
@@ -62,6 +72,7 @@ void rtmp2_chunk_parser_v2_clear (Rtmp2ChunkParserV2 *parser);
 gboolean rtmp2_chunk_parser_v2_read_message (Rtmp2ChunkParserV2 *parser, 
                                               Rtmp2ChunkMessage **message,
                                               GError **error);
+void rtmp2_chunk_parser_v2_dump_diagnostics (Rtmp2ChunkParserV2 *parser);
 
 void rtmp2_chunk_v2_debug_init (void);
 

--- a/gst/rtmp2client.c
+++ b/gst/rtmp2client.c
@@ -1161,10 +1161,11 @@ rtmp2_client_process_data (Rtmp2Client * client, GError ** error)
             tag->data_size = 11 + msg->message_length + 4;
             tag->data = flv_tag_buffer; /* Transfer ownership */
             
+            g_mutex_lock (&client->flv_parser.pending_tags_lock);
             client->flv_parser.pending_tags = 
                 g_list_append (client->flv_parser.pending_tags, tag);
-            
             gint pending_count = g_list_length (client->flv_parser.pending_tags);
+            g_mutex_unlock (&client->flv_parser.pending_tags_lock);
             GST_INFO ("✅ CREATED FLV TAG #%d: type=%s size=%u ts=%u (queue=%d tags)",
                 pending_count, 
                 tag->tag_type == RTMP2_FLV_TAG_VIDEO ? "video" : "audio",

--- a/gst/rtmp2flv.c
+++ b/gst/rtmp2flv.c
@@ -68,15 +68,19 @@ rtmp2_flv_parser_init (Rtmp2FlvParser * parser)
   parser->pending_tags = NULL;
   parser->have_video_caps = FALSE;
   parser->have_audio_caps = FALSE;
+  g_mutex_init (&parser->pending_tags_lock);
 }
 
 void
 rtmp2_flv_parser_clear (Rtmp2FlvParser * parser)
 {
+  g_mutex_lock (&parser->pending_tags_lock);
   if (parser->pending_tags) {
     g_list_free_full (parser->pending_tags, (GDestroyNotify) rtmp2_flv_tag_free);
     parser->pending_tags = NULL;
   }
+  g_mutex_unlock (&parser->pending_tags_lock);
+  g_mutex_clear (&parser->pending_tags_lock);
 }
 
 gboolean

--- a/gst/rtmp2flv.h
+++ b/gst/rtmp2flv.h
@@ -87,6 +87,7 @@ typedef struct {
   GList *pending_tags;
   gboolean have_video_caps;
   gboolean have_audio_caps;
+  GMutex pending_tags_lock;
 } Rtmp2FlvParser;
 
 void rtmp2_flv_parser_init (Rtmp2FlvParser *parser);


### PR DESCRIPTION
## Summary
- fix rtmp2 fast buffer compaction + add detailed diagnostics for fmt/csid/type parsing so mis-sized chunks are visible in logs
- guard `Rtmp2FlvParser.pending_tags` with a mutex and ensure the serversrc consumer locks before iterating, eliminating the g_list_length crash
- document the parser fix + add a PR execution prompt so future handoffs cover commit/push/merge explicitly

## Testing
- `GST_PLUGIN_PATH=$(pwd)/build gst-launch-1.0 rtmp2serversrc port=1935 ! filesink location=test_video_only.flv` + `ffmpeg -re -f lavfi -i testsrc=duration=2:rate=30 -c:v libx264 -preset ultrafast -g 30 -f flv rtmp://localhost:1935/live/test` → `ffprobe` shows 60/60 video frames
- same gst-launch pipeline + ffmpeg with audio (`-f lavfi -i sine=duration=2 -c:a aac`) → `ffprobe` shows 60/60 video frames and 88 audio packets
- manual SRT pipeline sanity check (rtmp2serversrc → flvdemux → mpegtsmux → srtsink) to confirm muxing works, though timestamp backpressure investigation continues in next task

